### PR TITLE
Added nuts.agb.role attribute

### DIFF
--- a/nuts/Issues/agb/description.xml
+++ b/nuts/Issues/agb/description.xml
@@ -30,5 +30,15 @@
 				<nl>unieke identificerende sleutel van individuele zorgverleners en zorgorganisaties</nl>
 			</Description>
 		</Attribute>
+		<Attribute id="role">
+			<Name>
+				<en>role</en>
+				<nl>rol</nl>
+			</Name>
+			<Description>
+				<en>care provider role related to the uniquely identifying key</en>
+				<nl>zorgverlenersrol met betrekking tot de unieke code</nl>
+			</Description>
+		</Attribute>
 	</Attributes>
 </IssueSpecification>

--- a/nuts/Issues/agb/description.xml
+++ b/nuts/Issues/agb/description.xml
@@ -30,7 +30,7 @@
 				<nl>unieke identificerende sleutel van individuele zorgverleners en zorgorganisaties</nl>
 			</Description>
 		</Attribute>
-		<Attribute id="role">
+		<Attribute id="role" optional="true">
 			<Name>
 				<en>role</en>
 				<nl>rol</nl>


### PR DESCRIPTION
Used for team members that can use the agbcode but do not own it.

In healthcare terms. A GP 'owns' the agbcode but members of the staff are allowed to use it. Issuance will be done by the owner of the agbcode. He or she will login using BRP attributes. After validating the agbcode, the owner will choose a role and will let the staff member scan the resulting QR-code