### PR TITLE
Fix: allow fork PR checkout in pull-request-review workflow

### DIFF
--- a/.github/workflows/pull-request-review.yml
+++ b/.github/workflows/pull-request-review.yml
@@ -18,6 +18,15 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Gate the whole job behind a manual approval. Because this is a
+    # pull_request_target workflow that checks out and runs against untrusted
+    # fork code (see allow-unsafe-pr-checkout below), a maintainer must approve
+    # each run via the "fork-pr-review" environment's required reviewers.
+    # Approval is requested again on every new push to the PR.
+    # NOTE: an org admin must configure Settings > Environments > fork-pr-review
+    # with required reviewers, otherwise the environment is auto-created with no
+    # protection and the gate does nothing.
+    environment: fork-pr-review
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout pull request base
@@ -32,9 +41,9 @@ jobs:
           path: ./head
           ref: ${{ github.event.pull_request.head.sha }}
           # actions/checkout@v7 refuses to check out fork PR code in a
-          # pull_request_target workflow unless explicitly opted in. This is safe
-          # here: no fork-controlled code is executed; the trusted yivi binary only
-          # parses the fork's scheme data files.
+          # pull_request_target workflow unless explicitly opted in. The job is
+          # gated behind the fork-pr-review environment (above), so a maintainer
+          # reviews the fork's code before this runs.
           allow-unsafe-pr-checkout: true
 
       - name: Initialize ~/.local/bin directory

--- a/.github/workflows/pull-request-review.yml
+++ b/.github/workflows/pull-request-review.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           path: ./head
           ref: ${{ github.event.pull_request.head.sha }}
+          # actions/checkout@v7 refuses to check out fork PR code in a
+          # pull_request_target workflow unless explicitly opted in. This is safe
+          # here: no fork-controlled code is executed; the trusted yivi binary only
+          # parses the fork's scheme data files.
+          allow-unsafe-pr-checkout: true
 
       - name: Initialize ~/.local/bin directory
         run: |

--- a/.github/workflows/pull-request-review.yml
+++ b/.github/workflows/pull-request-review.yml
@@ -18,15 +18,6 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Gate the whole job behind a manual approval. Because this is a
-    # pull_request_target workflow that checks out and runs against untrusted
-    # fork code (see allow-unsafe-pr-checkout below), a maintainer must approve
-    # each run via the "fork-pr-review" environment's required reviewers.
-    # Approval is requested again on every new push to the PR.
-    # NOTE: an org admin must configure Settings > Environments > fork-pr-review
-    # with required reviewers, otherwise the environment is auto-created with no
-    # protection and the gate does nothing.
-    environment: fork-pr-review
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout pull request base
@@ -41,9 +32,9 @@ jobs:
           path: ./head
           ref: ${{ github.event.pull_request.head.sha }}
           # actions/checkout@v7 refuses to check out fork PR code in a
-          # pull_request_target workflow unless explicitly opted in. The job is
-          # gated behind the fork-pr-review environment (above), so a maintainer
-          # reviews the fork's code before this runs.
+          # pull_request_target workflow unless explicitly opted in. This is safe
+          # here: no fork-controlled code is executed; the trusted yivi binary only
+          # parses the fork's scheme data files.
           allow-unsafe-pr-checkout: true
 
       - name: Initialize ~/.local/bin directory


### PR DESCRIPTION
## Problem

The `review` job in `pull-request-review.yml` fails at the **Checkout pull request head** step for any fork PR:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. ... To opt in ... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

`actions/checkout@v7` added a guard that refuses to check out fork PR code inside a `pull_request_target` workflow unless explicitly opted in ([pwn request protection](https://gh.io/securely-using-pull_request_target)). Since the workflow checks out the PR head SHA (fork code) into `./head`, this breaks CI for **every cross-repository PR** (e.g. #173).

## Fix

Set `allow-unsafe-pr-checkout: true` on the head checkout step.

**Why this is safe here:** the "pwn request" risk is *executing* fork-controlled code (build scripts, install hooks, etc.) in the privileged, secret-bearing context. This workflow does not do that:
- the job's token is scoped to `pull-requests: write` only, so it can't push code;
- no secrets are referenced;
- it only runs the trusted `yivi` binary (downloaded from the official irmago releases) to *parse* the fork's scheme data files — no fork-controlled code path executes.